### PR TITLE
Remove unnecessary call to .end()

### DIFF
--- a/routes/authenticate.js
+++ b/routes/authenticate.js
@@ -20,10 +20,9 @@ router.get('/login', function (req, res, next) {
 
 router.post('/logout', function (req, res, next) {
 
-    req.session.destroy();
     res.status(200)
-        .send({next: "/authenticate/login"})
-        .end();
+        .send({next: "/authenticate/login"});
+    req.session.destroy();
 });
 
 /* POST user auth. */


### PR DESCRIPTION
Calling response.send() internally executes end() function. Remove to
avoid unexpected behavior.

Signed-off-by: Jorge A Villalobos <jorge.villalobos.gutierrez@intel.com>