### PR TITLE
Makefile integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# Variable declaration
+
+NODE_ENV="production"
+file="$(NODE_ENV)_template.ejs"
+cssStart="<link rel='stylesheet' href='"
+cssEnd="' />"
+jsStart="<script type='text/javascript' src='"
+jsEnd="'></script>"
+match="</title>"
+# * "files" *
+bootstrap="$(cssStart)/bootstrap/dist/css/bootstrap.min.css$(cssEnd)"
+framework="$(cssStart)/stylesheets/framework.css$(cssEnd)"
+d3="$(cssStart)/stylesheets/d3Framework.css$(cssEnd)"
+jquery="$(jsStart)/jquery/dist/jquery.js$(jsEnd)"
+jqueryui="$(jsStart)/jquery-ui/jquery-ui.js$(jsEnd)"
+datamanager="$(jsStart)/data/dataManager.js$(jsEnd)"
+loadDatamanager="<script type='text/javascript'>window.datamanager.loadData\(\(<%- JSON.stringify\(data\)%>\)\);</script>"
+validations="$(jsStart)/javascripts/library/validations.js$(jsEnd)"
+
+all:
+	mkdir -p public/javascripts/library
+	mkdir node_modules
+	mkdir -p build/stylesheets
+	cp views/default_template.ejs views/$(file)
+	cp css/css_framework/framework.css build/stylesheets
+	cp css/d3_components/d3Framework.css build/stylesheets
+	cp -r vendor/* node_modules/
+	cp js/util/*.js public/javascripts/library/
+	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
+
+clean:
+	rm -rf node_modules
+	rm -rf public/*
+	rm -rf build
+	rm views/$(file)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Variable declaration
 
-NODE_ENV="production"
+#NODE_ENV="production"
+NPM_LINK=$(shell npm bin -g)
 file="$(NODE_ENV)_template.ejs"
 cssStart="<link rel='stylesheet' href='"
 cssEnd="' />"
@@ -18,18 +19,58 @@ loadDatamanager="<script type='text/javascript'>window.datamanager.loadData\(\(<
 validations="$(jsStart)/javascripts/library/validations.js$(jsEnd)"
 
 all:
-	mkdir -p public/javascripts/library
-	mkdir node_modules
-	mkdir -p build/stylesheets
-	cp views/default_template.ejs views/$(file)
-	cp css/css_framework/framework.css build/stylesheets
-	cp css/d3_components/d3Framework.css build/stylesheets
-	cp -r vendor/* node_modules/
-	cp js/util/*.js public/javascripts/library/
+	-mkdir -p public/javascripts/library
+	-mkdir node_modules
+	-mkdir -p build/stylesheets
+	-cp views/default_template.ejs views/$(file)
+	-cp css/css_framework/framework.css build/stylesheets
+	-cp css/d3_components/d3Framework.css build/stylesheets
+	-cp -r vendor/* node_modules/
+	-cp js/util/*.js public/javascripts/library/
 	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
+	-mkdir -p /usr/share/ciao-webui
+	-cp config/ciao_config.json /usr/share/ciao-webui/
+	-mkdir -p /usr/local/ciao-webui/
+	-cp -rf * /usr/local/ciao-webui/
+	-cp ./ciao-webui.sh $(NPM_LINK)/ciao-webui
+
+uninstall:
+	-rm -r /usr/local/ciao-webui
+	-rm /usr/share/ciao-webui/ciao_config.json
+
+install:
+	# Update/download the required dependencies for the project
+	npm install
+	# installing Babel and Browserify globally
+	npm install --global babel-cli
+	npm install --global browserify
+	#Build react + jsx code and put in build directory
+	npm run babel-react
+	# Run build scripts
+	npm run build-login
+	npm run build-tenant
+	npm run build-admin
+	npm run build-machine
+	npm run build-network
+	npm run build-subnet
+	npm run build-group
+		-mkdir -p public/javascripts/library
+	-mkdir node_modules
+	-mkdir -p build/stylesheets
+	-cp views/default_template.ejs views/$(file)
+	-cp css/css_framework/framework.css build/stylesheets
+	-cp css/d3_components/d3Framework.css build/stylesheets
+	-cp -r vendor/* node_modules/
+	-cp js/util/*.js public/javascripts/library/
+	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
+	-mkdir -p /usr/share/ciao-webui
+	-cp config/ciao_config.json /usr/share/ciao-webui/
+	-mkdir -p /usr/local/ciao-webui/
+	-cp -rf * /usr/local/ciao-webui/
+	-cp ./ciao-webui.sh $(NPM_LINK)/ciao-webui
 
 clean:
-	rm -rf node_modules
-	rm -rf public/*
-	rm -rf build
-	rm views/$(file)
+	-rm -rf node_modules
+	-rm build/javascripts/.*js
+	-rm -rf public/*
+	-rm views/$(file)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Variable declaration
 
-NODE_ENV="production"
+DESTDIR ?= /usr/local
+NODE_ENV ?="production"
 OS=$(shell uname)
 NPM_LINK=$(shell npm bin -g)
 file="$(NODE_ENV)_template.ejs"
@@ -19,7 +20,7 @@ datamanager="$(jsStart)/data/dataManager.js$(jsEnd)"
 loadDatamanager="<script type='text/javascript'>window.datamanager.loadData\(\(<%- JSON.stringify\(data\)%>\)\);</script>"
 validations="$(jsStart)/javascripts/library/validations.js$(jsEnd)"
 
-all:
+install:
 	-mkdir -p public/javascripts/library
 	-mkdir node_modules
 	-mkdir -p build/stylesheets
@@ -29,32 +30,35 @@ all:
 	-cp -r vendor/* node_modules/
 	-cp js/util/*.js public/javascripts/library/
 	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
-	-mkdir -p /usr/local/ciao-webui/
+	-mkdir -p $(DESTDIR)/ciao-webui/
 ifeq ($(OS), Darwin)
-	-mkdir -p /usr/local/share/ciao-webui
-	-cp config/ciao_config.json /usr/local/share/ciao-webui/
+	-mkdir -p $(DESTDIR)/share/ciao-webui
+	-cp config/ciao_config.json $(DESTDIR)/share/ciao-webui/
 else
 	-mkdir -p /usr/share/ciao-webui
 	-cp config/ciao_config.json /usr/share/ciao-webui/
 endif
-	-cp -rf * /usr/local/ciao-webui/
-	-cp ./ciao-webui.sh $(NPM_LINK)/ciao-webui
+	-cp -rf * $(DESTDIR)/ciao-webui/
+	sed "s/\".\" #executable/\"$(subst $\/,\\/,$(DESTDIR))\"/" ./ciao-webui.sh > $(NPM_LINK)/ciao-webui
+	chmod u+rx $(NPM_LINK)/ciao-webui
 
 uninstall:
 ifeq ($(OS), Darwin)
-	-rm /usr/local/share/ciao-webui/ciao_config.json
+	-rm $(DESTDIR)/share/ciao-webui/ciao_config.json
 else
 	-rm /usr/share/ciao-webui/ciao_config.json
 endif
 	-rm -r /usr/local/ciao-webui
 	-rm $(NPM_LINK)/ciao-webui
 
-install:
+install-dev:
 	# Update/download the required dependencies for the project
+	-cp -r vendor/* node_modules/
 	-npm install
 	# installing Babel and Browserify globally
 	-npm install --global babel-cli
 	-npm install --global browserify
+	-npm install --global babel-preset-es2015 babel-preset-react
 	#Build react + jsx code and put in build directory
 	-npm run babel-react
 	# Run build scripts
@@ -71,19 +75,19 @@ install:
 	-cp views/default_template.ejs views/$(file)
 	-cp css/css_framework/framework.css build/stylesheets
 	-cp css/d3_components/d3Framework.css build/stylesheets
-	-cp -r vendor/* node_modules/
 	-cp js/util/*.js public/javascripts/library/
 	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
-	-mkdir -p /usr/local/ciao-webui/
+	-mkdir -p $(DESTDIR)/ciao-webui/
 ifeq ($(OS), Darwin)
-	-mkdir -p /usr/local/share/ciao-webui
-	-cp config/ciao_config.json /usr/local/share/ciao-webui/
+	-mkdir -p $(DESTDIR)/share/ciao-webui
+	-cp config/ciao_config.json $(DESTDIR)/share/ciao-webui/
 else
 	-mkdir -p /usr/share/ciao-webui
 	-cp config/ciao_config.json /usr/share/ciao-webui/
 endif
-	-cp -rf * /usr/local/ciao-webui/
-	-cp ./ciao-webui.sh $(NPM_LINK)/ciao-webui
+	-cp -rf * $(DESTDIR)/ciao-webui/
+	sed "s/\".\" #executable/\"$(subst $\/,\\/,$(DESTDIR))\"/" ./ciao-webui.sh > $(NPM_LINK)/ciao-webui
+	chmod u+rx $(NPM_LINK)/ciao-webui
 
 clean:
 	-rm -rf node_modules

--- a/Makefile
+++ b/Makefile
@@ -31,23 +31,14 @@ install:
 	-cp js/util/*.js public/javascripts/library/
 	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
 	-mkdir -p $(DESTDIR)/ciao-webui/
-ifeq ($(OS), Darwin)
 	-mkdir -p $(DESTDIR)/share/ciao-webui
 	-cp config/ciao_config.json $(DESTDIR)/share/ciao-webui/
-else
-	-mkdir -p /usr/share/ciao-webui
-	-cp config/ciao_config.json /usr/share/ciao-webui/
-endif
 	-cp -rf * $(DESTDIR)/ciao-webui/
 	sed "s/\".\" #executable/\"$(subst $\/,\\/,$(DESTDIR))\"/" ./ciao-webui.sh > $(NPM_LINK)/ciao-webui
 	chmod u+rx $(NPM_LINK)/ciao-webui
 
 uninstall:
-ifeq ($(OS), Darwin)
 	-rm $(DESTDIR)/share/ciao-webui/ciao_config.json
-else
-	-rm /usr/share/ciao-webui/ciao_config.json
-endif
 	-rm -r /usr/local/ciao-webui
 	-rm $(NPM_LINK)/ciao-webui
 
@@ -78,13 +69,8 @@ install-dev:
 	-cp js/util/*.js public/javascripts/library/
 	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
 	-mkdir -p $(DESTDIR)/ciao-webui/
-ifeq ($(OS), Darwin)
 	-mkdir -p $(DESTDIR)/share/ciao-webui
 	-cp config/ciao_config.json $(DESTDIR)/share/ciao-webui/
-else
-	-mkdir -p /usr/share/ciao-webui
-	-cp config/ciao_config.json /usr/share/ciao-webui/
-endif
 	-cp -rf * $(DESTDIR)/ciao-webui/
 	sed "s/\".\" #executable/\"$(subst $\/,\\/,$(DESTDIR))\"/" ./ciao-webui.sh > $(NPM_LINK)/ciao-webui
 	chmod u+rx $(NPM_LINK)/ciao-webui

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ else
 	-rm /usr/share/ciao-webui/ciao_config.json
 endif
 	-rm -r /usr/local/ciao-webui
+	-rm $(NPM_LINK)/ciao-webui
 
 install:
 	# Update/download the required dependencies for the project

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Variable declaration
 
-#NODE_ENV="production"
+NODE_ENV="production"
+OS=$(shell uname)
 NPM_LINK=$(shell npm bin -g)
 file="$(NODE_ENV)_template.ejs"
 cssStart="<link rel='stylesheet' href='"
@@ -28,33 +29,42 @@ all:
 	-cp -r vendor/* node_modules/
 	-cp js/util/*.js public/javascripts/library/
 	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
+	-mkdir -p /usr/local/ciao-webui/
+ifeq ($(OS), Darwin)
+	-mkdir -p /usr/local/share/ciao-webui
+	-cp config/ciao_config.json /usr/local/share/ciao-webui/
+else
 	-mkdir -p /usr/share/ciao-webui
 	-cp config/ciao_config.json /usr/share/ciao-webui/
-	-mkdir -p /usr/local/ciao-webui/
+endif
 	-cp -rf * /usr/local/ciao-webui/
 	-cp ./ciao-webui.sh $(NPM_LINK)/ciao-webui
 
 uninstall:
-	-rm -r /usr/local/ciao-webui
+ifeq ($(OS), Darwin)
+	-rm /usr/local/share/ciao-webui/ciao_config.json
+else
 	-rm /usr/share/ciao-webui/ciao_config.json
+endif
+	-rm -r /usr/local/ciao-webui
 
 install:
 	# Update/download the required dependencies for the project
-	npm install
+	-npm install
 	# installing Babel and Browserify globally
-	npm install --global babel-cli
-	npm install --global browserify
+	-npm install --global babel-cli
+	-npm install --global browserify
 	#Build react + jsx code and put in build directory
-	npm run babel-react
+	-npm run babel-react
 	# Run build scripts
-	npm run build-login
-	npm run build-tenant
-	npm run build-admin
-	npm run build-machine
-	npm run build-network
-	npm run build-subnet
-	npm run build-group
-		-mkdir -p public/javascripts/library
+	-npm run build-login
+	-npm run build-tenant
+	-npm run build-admin
+	-npm run build-machine
+	-npm run build-network
+	-npm run build-subnet
+	-npm run build-group
+	-mkdir -p public/javascripts/library
 	-mkdir node_modules
 	-mkdir -p build/stylesheets
 	-cp views/default_template.ejs views/$(file)
@@ -63,9 +73,14 @@ install:
 	-cp -r vendor/* node_modules/
 	-cp js/util/*.js public/javascripts/library/
 	sed -i.bak "s~$(subst $\",,$(match))~$(subst $\",,$(match))\\$(bootstrap)\\$(subst $\",,$(framework))\\$(subst $\",,$(d3))\\ $(subst $\",,$(jquery))\\$(subst $\",,$(jqueryui))\\$(subst $\",,$(datamanager))\\$(subst $\",,$(loadDatamanager))\\ $(subst $\",,$(validations))~" views/$(subst $\",,$(file))
+	-mkdir -p /usr/local/ciao-webui/
+ifeq ($(OS), Darwin)
+	-mkdir -p /usr/local/share/ciao-webui
+	-cp config/ciao_config.json /usr/local/share/ciao-webui/
+else
 	-mkdir -p /usr/share/ciao-webui
 	-cp config/ciao_config.json /usr/share/ciao-webui/
-	-mkdir -p /usr/local/ciao-webui/
+endif
 	-cp -rf * /usr/local/ciao-webui/
 	-cp ./ciao-webui.sh $(NPM_LINK)/ciao-webui
 

--- a/ciao-webui.sh
+++ b/ciao-webui.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+if [ "$1" == "" ]; then
+    env="production"
+else
+    env=$1
+fi
+echo "Environment: "$env
+
+export NODE_ENV=$env
+
+if [ "$2" == "" ]; then
+    node /usr/local/ciao-webui/bin/www  "config_file=/usr/share/ciao-webui/ciao_config.json"
+
+else
+    node /usr/local/ciao-webui/bin/www " $@"
+fi

--- a/ciao-webui.sh
+++ b/ciao-webui.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-
+OS=`uname`
+CONFIG_FILE='config_file=/usr/share/ciao-webui/ciao_config.json'
+if [[ "$OS" == 'Darwin' ]]; then
+	CONFIG_FILE='config_file=/usr/local/share/ciao-webui/ciao_config.json'
+fi
 
 if [ "$1" == "" ]; then
     env="production"
@@ -11,7 +15,7 @@ echo "Environment: "$env
 export NODE_ENV=$env
 
 if [ "$2" == "" ]; then
-    node /usr/local/ciao-webui/bin/www  "config_file=/usr/share/ciao-webui/ciao_config.json"
+    node /usr/local/ciao-webui/bin/www "$CONFIG_FILE" 
 
 else
     node /usr/local/ciao-webui/bin/www " $@"

--- a/ciao-webui.sh
+++ b/ciao-webui.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 OS=`uname`
 LOCATION="." #executable
-CONFIG_FILE='config_file=/usr/share/ciao-webui/ciao_config.json'
-if [[ "$OS" == 'Darwin' ]]; then
-    CONFIG_FILE='config_file=/usr/local/share/ciao-webui/ciao_config.json'
-fi
+CONFIG_FILE="config_file=$LOCATION/share/ciao-webui/ciao_config.json"
 
 if [ "$1" == "" ]; then
     env="production"

--- a/ciao-webui.sh
+++ b/ciao-webui.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 OS=`uname`
+LOCATION="." #executable
 CONFIG_FILE='config_file=/usr/share/ciao-webui/ciao_config.json'
 if [[ "$OS" == 'Darwin' ]]; then
-	CONFIG_FILE='config_file=/usr/local/share/ciao-webui/ciao_config.json'
+    CONFIG_FILE='config_file=/usr/local/share/ciao-webui/ciao_config.json'
 fi
 
 if [ "$1" == "" ]; then
@@ -15,8 +16,8 @@ echo "Environment: "$env
 export NODE_ENV=$env
 
 if [ "$2" == "" ]; then
-    node /usr/local/ciao-webui/bin/www "$CONFIG_FILE" 
+    node $LOCATION/ciao-webui/bin/www "$CONFIG_FILE"
 
 else
-    node /usr/local/ciao-webui/bin/www " $@"
+    node $LOCATION/ciao-webui/bin/www " $@"
 fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "babel-react": "babel --presets react js/ --watch --out-dir build",
+    "babel-react": "babel --presets react js/ --out-dir build",
     "build-tenant-detail": "browserify build/pages/tenant_usage_details.js -o build/javascripts/bundle_tenant_usage_detail.js",
     "build-login": "browserify build/pages/login_page.js -o build/javascripts/bundle_login.js",
     "build-tenant": "browserify build/pages/tenant_admin.js -o build/javascripts/bundle_tenant_admin.js",


### PR DESCRIPTION
After executing "make" a "ciao-webui" command will be able for usage in the system. Functionality resembles "npm start" and "deploy.sh". defaults to a production environment.
"Make install" should replace usage of ./install.sh
use "make clean" to remove generated files locally and "make unisntall" to remove application from the system.
  
- make: set up application (as it is distributed) in the system
    - make install: same as make + install all development dependencies
    - make clean: cleans local directory from generated files
    - make uninstall: cleans generated files from system
    - added ciao-webui.sh: script that resembles ciao-webui which is to be
      set to PATH for system execution.
