### PR TITLE
Fixes Makefile not building all requirements on install-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ install-dev:
 	-npm run build-network
 	-npm run build-subnet
 	-npm run build-group
+	-npm run build-notice
 	-npm run build-forbidden
 	-npm run build-tenant-detail
+	-npm run build-detailby-tenant
 	-mkdir -p public/javascripts/library
 	-mkdir -p public/stylesheets
 	-cp views/default_template.ejs views/$(file)


### PR DESCRIPTION
- Fixes #192, Makefile - install-dev not building notice and detailby-tenant

Signed-off-by: Arturo Nunez <arturo.nunez@intel.com>