### PR TITLE
Fix tenant name in navbar on admin overview page

### DIFF
--- a/js/components/navbar.js
+++ b/js/components/navbar.js
@@ -38,11 +38,11 @@ var navbar = React.createClass({
             </NavDropdown>);
     },
     getTenantMenu: function () {
-        var title = (this.state.tenant)?this.state.tenant.name:'';
-
         if ((window.location.pathname).substr(0,7) === "/tenant") {
+            var title = (this.state.tenant)?this.state.tenant.name:'';
             var reference = "/tenant/";
         } else {
+            var title = (this.state.tenant)?this.state.tenant.name:'admin';
             var reference = "/admin/tenantDetail/";
         }
 


### PR DESCRIPTION
- Fixes #201, Tenant selector does not display name in admin overview page.

Signed-off-by: Arturo Nunez <arturo.nunez@intel.com>