### PR TITLE
Create volumes http request fixed

### DIFF
--- a/core/blockService.js
+++ b/core/blockService.js
@@ -54,7 +54,8 @@ blockService.prototype.createVolume = function () {
         if (req.body.description) {
             jsonBody.volume.description = req.body.description;
         }
-
+        // Forces json value int to be treated as string
+        jsonBody.volume.size = parseInt(jsonBody.volume.size);
         return adapter.onSuccess((data) => res.send(data.json))
             .onError((data) => res.send(data))
             .post(uri, jsonBody, req.session.token);


### PR DESCRIPTION
Because of how json objects are handled by nodejs, it was mapping an int
value to string. This patch forces that format to remain integer.
Fixes #253

Signed-off-by: Jorge Villalobos <jorge.villalobos.gutierrez@intel.com>