### PR TITLE
Makefile's DESTDIR variable to be inside npm's PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variable declaration
 
-DESTDIR ?= /usr/local
+DESTDIR ?= $(shell npm config get prefix)
 NODE_ENV ?="production"
 OS=$(shell uname)
 NPM_LINK=$(shell npm bin -g)


### PR DESCRIPTION
- Fixes #252, DESTDIR should accesible by non-root user

Signed-off-by: Arturo Nunez <arturo.nunez@intel.com>