### PR TITLE
Adding bootable volume interface

### DIFF
--- a/core/blockService.js
+++ b/core/blockService.js
@@ -49,8 +49,10 @@ blockService.prototype.createVolume = function () {
         var jsonBody = req.body.volume? req.body :{ volume: {
             size:req.body.size,
             name: req.body.name,
-            imageRef:req.body.imageRef
-        }};
+                    }};
+        if (req.body.imageRef != "--none--") {
+           jsonBody.volume.imageRef=req.body.imageRef
+        }
         // add optional values
         if (req.body.description) {
             jsonBody.volume.description = req.body.description;

--- a/core/blockService.js
+++ b/core/blockService.js
@@ -48,7 +48,8 @@ blockService.prototype.createVolume = function () {
 
         var jsonBody = req.body.volume? req.body :{ volume: {
             size:req.body.size,
-            name: req.body.name
+            name: req.body.name,
+            imageRef:req.body.imageRef
         }};
         // add optional values
         if (req.body.description) {

--- a/core/ciao_adapter.js
+++ b/core/ciao_adapter.js
@@ -33,6 +33,12 @@ ciaoAdapter.prototype.useNode = function (node) {
     return ca;
 };
 
+ciaoAdapter.prototype.useSetup = function (obj) {
+    var ca = new ciaoAdapter();
+    ca.setup(obj.hostname,obj.port,obj.protocol);
+    return ca;
+}
+
 ciaoAdapter.prototype.onSuccess = function (callback) {
     var ca = Object.assign(new ciaoAdapter(this.host, this.port, this.protocol),
                            this);

--- a/core/imageService.js
+++ b/core/imageService.js
@@ -12,7 +12,7 @@ imageService.prototype.getImages = function () {
     var adapter = this.adapter;
     var tokenManager = this.tokenManager;
     return function(req, res, next) {
-        var uri = "/v2/"+req.params.tenant+"/images";
+        var uri = "/v2/images";
         return adapter.onSuccess((data) => res.send(data.json))
             .onError((data) => res.send(data))
             .get(uri,req.session.token);

--- a/js/components/catalogue/customModal.js
+++ b/js/components/catalogue/customModal.js
@@ -109,15 +109,17 @@ var customModal = React.createClass({
                             );
                     break;
                 case "select":
-                    return <Select
+                    return <Input
                             id={row.id}
+                            type="select"
                             name={row.id}
                             label={label}
                             value={this.state.data[row.name]}
                             placeholder={row.placeholder?row.placeholder:""}
                             onChange={this.onChange.bind(this, row.name)}
-                            options={row.options}
-                            />;
+                            >
+                                {row.options}
+                            </Input>;
 
                     break;
                 default:

--- a/js/pages/tenant_detail.js
+++ b/js/pages/tenant_detail.js
@@ -97,6 +97,25 @@ $('document').ready(function () {
     };
     getFlavors(0);
 
+    var getImages = function (attempts) {
+        $.get({
+            url:"/data/images",
+            timeout:5000})
+            .done(function (data) {
+                if (data) {
+                        datamanager.data.images = data.images;
+                }
+            }.bind(this))
+            .fail(function (err) {
+                if (attempts< 3)
+                    getImages(attempts +1);
+                else {
+                        datamanager.data.images = {};
+                }
+            });
+    };
+    getImages(0);
+
     //create instances host
     var keyInstanceHost = 'instances-host';
     datamanager.onDataSourceSet(keyInstanceHost, function (sourceData) {
@@ -192,16 +211,6 @@ $('document').ready(function () {
             validate:{
                 required:false
             }
-        },
-        {
-            id: 'volume_image',
-            type: 'text',
-            field: 'input',
-            name: 'imageRef',
-            label: 'Image UUID(Bootable only)',
-            validate: {
-                required: false
-            }
         }];
 
     // Actions definition - add functionality to buttons within volume table
@@ -214,6 +223,31 @@ $('document').ready(function () {
                 node.setAttribute('id',"temp-volume-create-modal");
                 if (!document.getElementById(node.id))
                     document.body.appendChild(node);
+                var imageList = [];
+                if (window.datamanager.data.flavors != undefined) {
+                    imageList = window.datamanager.data
+                        .images.map(
+                            (img)=>{
+                                return <option  
+                                    value={img.id}>
+                                {img.name}
+                                </option>;
+                            });
+                    imageList.push(<option value={null}>--none--</option>)
+                    if (modalCreateFields.filter((f) => f.id =='volume_image') == 0)
+                    modalCreateFields.push(
+                        {
+                            id: 'volume_image',
+                            field: 'select',
+                            placeholder:"",
+                            options: imageList,
+                            name: 'imageRef',
+                            label: 'Image UUID(Bootable only)',
+                            validate: {
+                                required: false
+                            }
+                        });
+                }
                 var modalParams = {
                     title: 'Create a Volume',
                     type:'form',
@@ -239,11 +273,12 @@ $('document').ready(function () {
                     document.body.appendChild(node);
                 //get volume list from datamanager available sources
                 var volumeSource = datamanager.sources[volumeComponent].data;
-                var volumeList = volumeSource ?
-                        volumeSource.map((i) => {
-                            return {value:i.volume_id, label:i.name};
-                        }) : [];
-
+                var volumeList = [];
+                if(volumeSource != undefined) {
+                    volumeList = volumeSource.map(function(i, n){
+                        return {value:i.volume_id,label:i.name};
+                    });
+                }
                 // TODO: check text format of options, could be more legible
                 // Create modal params for deletion
                 // if 1 or more volume is selected, just confirm

--- a/js/pages/tenant_detail.js
+++ b/js/pages/tenant_detail.js
@@ -192,6 +192,16 @@ $('document').ready(function () {
             validate:{
                 required:false
             }
+        },
+        {
+            id: 'volume_image',
+            type: 'text',
+            field: 'input',
+            name: 'imageRef',
+            label: 'Image UUID(Bootable only)',
+            validate: {
+                required: false
+            }
         }];
 
     // Actions definition - add functionality to buttons within volume table

--- a/routes/data.js
+++ b/routes/data.js
@@ -13,14 +13,21 @@ var ImageService = require('../core/imageService');
 var adapter = new ciaoAdapter();
 var tokenManager = new TokenManager(sessionHandler);
 
-var nodeService = new NodeService(adapter.useNode('controller'),
+var controllerAdapter = adapter.useNode('controller');
+var nodeService = new NodeService(controllerAdapter,
                                   tokenManager);
 var tenantService = new TenantService(adapter.useNode('controller'),
                                       tokenManager);
 var blockService = new BlockService(adapter.useNode('storage'),
                                     tokenManager);
-// ToDo: temporally using controller config until image config is added
-var imageService = new ImageService(adapter.useNode('controller'),
+
+//Note: using controller's hostname configuration and default port
+//and protocol
+var imageService = new ImageService(adapter.useSetup({
+                                        hostname:controllerAdapter.host,
+                                        port:"9292",
+                                        protocol:"https"
+                                    }),
                                     tokenManager);
 
 // Validate session as an authorized token is required
@@ -41,7 +48,7 @@ router.delete('/:tenant/servers/:server', function (req, res, next) {
 
 /* Endpoints for Image Service */
 // Image service GET Methods
-router.get('/:tenant/images', imageService.getImages());
+router.get('/images', imageService.getImages());
 router.get('/:tenant/images/:image_id', imageService.getImageDetails());
 
 // Image service POST Methods


### PR DESCRIPTION
Add 'bootable' and 'imageRef' fields required in order to create a bootable
volume at tenant_detail.js page. Also enable to send proper fields in json
request to controller.

TODO: 
Currently is functional feature, but image uuid must be retrieved manually.
Improve this by implementing a selector.

Signed-off-by: Jorge Villalobos <jorge.villalobos.gutierrez@intel.com>